### PR TITLE
updated the organization field label for clarity

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4537,6 +4537,7 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@memgraph/orb/-/orb-0.4.3.tgz",
       "integrity": "sha512-Pyf72ICS1nbecnPYjbwArzaf7lbGmfUImJmM9Ijc2G8/4lbqcNrAA+lznyNoFSkfLAjBAryI499UDre6RxDOhw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "d3-drag": "3.0.0",
         "d3-ease": "3.0.1",

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -108,7 +108,7 @@ const Home = () => {
                 spacing={{base: 7, lg: '90px'}}
               >
                 {[
-                  {text: 'Organization', key: 'institution'},
+                  {text: 'Organization (eg. University)', key: 'institution'},
                   {text: 'Type', key: 'type'},
                 ].map(({text, key}) => (
                   <Box key={text}>
@@ -117,7 +117,7 @@ const Home = () => {
                         <FormControl
                           isInvalid={form.errors[key] && form.touched[key]}
                         >
-                          {text === 'Organization' ? (
+                          {text === 'Organization (eg. University)' ? (
                             <>
                               <Input
                                 variant={'flushed'}


### PR DESCRIPTION
We have this `license` field auto-added in the package-lock.json file. I think this happened after I did the CollabNext development env setup. 