### PR TITLE
Refactored topic clusters

### DIFF
--- a/frontend/src/components/AllThreeMetadata.tsx
+++ b/frontend/src/components/AllThreeMetadata.tsx
@@ -1,10 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Box, Flex, Text } from '@chakra-ui/react';
 
 import { ResearchDataInterface } from '../utils/interfaces';
+import TopicClusterGraphComponent from './TopicClusterGraphComponent';
+import { TransformTopicClustersForOrb } from './TransformTopicCluster.js';
 
 const AllThreeMetadata = ({data}: {data: ResearchDataInterface}) => {
+
+  const [showTopicClusterGraph, setTopicClusterGraph] = useState(false);
+  const handleTopicClusterClick = () => {
+    setTopicClusterGraph(!showTopicClusterGraph);
+  }
+
   return (
     <Flex
       display={{base: 'block', lg: 'flex'}}
@@ -39,15 +47,13 @@ const AllThreeMetadata = ({data}: {data: ResearchDataInterface}) => {
         </a>
         <p>Total {data?.works_count} works</p>
         <p>Total {data?.cited_count} citations</p>
+
         <Box mt='0.4rem'>
           <Text fontSize={'17px'} fontWeight={'600'}>
-            Topic Clusters
+            <a style={{ cursor: 'pointer', textDecoration: 'underline' }} onClick={handleTopicClusterClick}>
+              Topic Clusters
+            </a>
           </Text>
-          <Box ml='2rem'>
-            {data?.topic_clusters?.map((cluster) => (
-              <Text mt='0.3rem'>{cluster}</Text>
-            ))}
-          </Box>
         </Box>
         <a target='_blank' rel='noreferrer' href={data?.open_alex_link}>
           View Institution on OpenAlex
@@ -63,7 +69,12 @@ const AllThreeMetadata = ({data}: {data: ResearchDataInterface}) => {
           View Researcher on OpenAlex
         </a>
       </Box>
-      <Box w={{lg: '64%'}} mt={{base: '.9rem', lg: 0}}>
+      {showTopicClusterGraph ? (
+        <Box mt='1rem' w={{ lg: '70%' }} mx='auto'>
+        <TopicClusterGraphComponent graphData={TransformTopicClustersForOrb(data, data?.topic_clusters)} />
+      </Box>
+      ) : (
+        <Box w={{lg: '64%'}} mt={{base: '.9rem', lg: 0}}>
         <Box display={'flex'} justifyContent={'space-between'}>
           <Text fontSize={'18px'} fontWeight={600} w='72%'>
             Work
@@ -85,6 +96,7 @@ const AllThreeMetadata = ({data}: {data: ResearchDataInterface}) => {
           ))}
         </Box>
       </Box>
+      )}
     </Flex>
   );
 };

--- a/frontend/src/components/TopicClusterGraphComponent.js
+++ b/frontend/src/components/TopicClusterGraphComponent.js
@@ -10,7 +10,7 @@ const TopicClusterGraphComponent = ({ graphData }) => {
       return; // Exit early if no data is provided
     }
 
-    const { nodes } = graphData;
+    const { nodes, edges } = graphData;
     const container = graphContainerRef.current;
     const orb = new Orb(container);
 
@@ -41,23 +41,18 @@ const TopicClusterGraphComponent = ({ graphData }) => {
             zIndex: 1,
           };
         }
-
-        if (node.data.type === 'INSTITUTION') {
-          return {
-            ...basicStyle,
-            size: 10,
-            color: '#88CCEE',
-            zIndex: 1,
-          };
-        }
-
+        return basicStyle;
+      },
+      getEdgeStyle() {
         return {
-          ...basicStyle,
+          color: '#999999',
+          colorSelected: '#1d1d1d',
+          width: 0.3,
         };
-      },    
+      },
     });
 
-    orb.data.setup({ nodes });
+    orb.data.setup({ nodes, edges });
 
     orb.view.render(() => {
       orb.view.recenter();

--- a/frontend/src/components/TopicClusterGraphComponent.js
+++ b/frontend/src/components/TopicClusterGraphComponent.js
@@ -1,0 +1,74 @@
+import React, { useEffect, useRef } from 'react';
+import { Orb } from '@memgraph/orb';
+import { Box } from '@chakra-ui/react';
+
+const TopicClusterGraphComponent = ({ graphData }) => {
+  const graphContainerRef = useRef(null);
+
+  useEffect(() => {
+    if (!graphData) {
+      return; // Exit early if no data is provided
+    }
+
+    const { nodes } = graphData;
+    const container = graphContainerRef.current;
+    const orb = new Orb(container);
+
+    orb.view.setSettings({
+      render: {
+        backgroundColor: '#f4faff',
+        padding: '0',
+        margin: '0',
+      },
+    });
+
+    orb.data.setDefaultStyle({
+      getNodeStyle(node) {
+        const basicStyle = {
+          borderColor: '#1d1d1d',
+          borderWidth: 0.6,
+          color: '#DD2222',
+          fontSize: 3,
+          label: node.data.label,
+          size: 6,
+        };
+
+        if (node.data.type === 'TOPIC') {
+          return {
+            ...basicStyle,
+            size: 10,
+            color: '#44AA99',
+            zIndex: 1,
+          };
+        }
+
+        if (node.data.type === 'INSTITUTION') {
+          return {
+            ...basicStyle,
+            size: 10,
+            color: '#88CCEE',
+            zIndex: 1,
+          };
+        }
+
+        return {
+          ...basicStyle,
+        };
+      },    
+    });
+
+    orb.data.setup({ nodes });
+
+    orb.view.render(() => {
+      orb.view.recenter();
+    });
+  }, [graphData]);
+
+  return (
+    <Box>
+      <div ref={graphContainerRef} id="graph" style={{ height: '500px', width: '100%' }} />
+    </Box>
+  );
+};
+
+export default TopicClusterGraphComponent;

--- a/frontend/src/components/TopicInstitutionMetadata.tsx
+++ b/frontend/src/components/TopicInstitutionMetadata.tsx
@@ -1,11 +1,15 @@
 import React, { useState } from 'react';
-
 import { Box, Flex, Text } from '@chakra-ui/react';
-
 import { ResearchDataInterface } from '../utils/interfaces';
 import TopicClusterGraphComponent from './TopicClusterGraphComponent';
 
-const TopicInstitutionMetadata = ({data }: {data: ResearchDataInterface}) => {
+const TopicInstitutionMetadata = ({
+  data,
+  setResearcher,
+}: {
+  data: ResearchDataInterface;
+  setResearcher: React.Dispatch<React.SetStateAction<string>>;
+}) => {
   const [showTopicClusterGraph, setTopicClusterGraph] = useState(false);
   const handleTopicClusterClick = () => {
     setTopicClusterGraph(!showTopicClusterGraph);
@@ -28,7 +32,6 @@ const TopicInstitutionMetadata = ({data }: {data: ResearchDataInterface}) => {
         label: topic,
         type: 'SUBFIELD',
       });
-      
     });
     return {
       nodes,
@@ -36,13 +39,13 @@ const TopicInstitutionMetadata = ({data }: {data: ResearchDataInterface}) => {
   };
 
   return (
-      <Flex
-      display={{ base: 'block', lg:'flex'}}
+    <Flex
+      display={{ base: 'block', lg: 'flex' }}
       justifyContent={'space-between'}
       mt='0.6rem'
       className='list-map'
-      >
-      <Box w={{lg: '34%'}}>
+    >
+      <Box w={{ lg: '34%' }}>
         <button className='topButton'>List Map</button>
         <h2>{data?.institution_name}</h2>
         <h2>{data?.topic_name}</h2>
@@ -65,19 +68,19 @@ const TopicInstitutionMetadata = ({data }: {data: ResearchDataInterface}) => {
 
         <Box mt='0.4rem'>
           <Text fontSize={'17px'} fontWeight={'600'}>
-            <a style={{ cursor: 'pointer', 'textDecoration': 'underline' }} onClick={handleTopicClusterClick}>
+            <a style={{ cursor: 'pointer', textDecoration: 'underline' }} onClick={handleTopicClusterClick}>
               Topic Clusters
             </a>
-          </Text> 
+          </Text>
         </Box>
       </Box>
 
       {showTopicClusterGraph ? (
-        <Box mt='1rem' w={{lg: '70%'}} mx = 'auto'>
-            <TopicClusterGraphComponent graphData={transformTopicClustersToGraph(data?.topic_clusters)} />
-          </Box>) 
-        : (
-          <Box w={{lg: '64%'}} mt={{base: '.9rem', lg: 0}}>
+        <Box mt='1rem' w={{ lg: '70%' }} mx='auto'>
+          <TopicClusterGraphComponent graphData={transformTopicClustersToGraph(data?.topic_clusters)} />
+        </Box>
+      ) : (
+        <Box w={{ lg: '64%' }} mt={{ base: '.9rem', lg: 0 }}>
           <Box display={'flex'} justifyContent={'space-between'}>
             <Text fontSize={'18px'} fontWeight={600} w='72%'>
               Person
@@ -89,7 +92,13 @@ const TopicInstitutionMetadata = ({data }: {data: ResearchDataInterface}) => {
           <Box mt='.5rem'>
             {data?.authors?.map((topic) => (
               <Flex justifyContent={'space-between'}>
-                <Text fontSize='14px' w='72%'>
+                <Text
+                  fontSize='14px'
+                  w='72%'
+                  onClick={() => setResearcher(topic[0])}
+                  textDecoration={'underline'}
+                  cursor='pointer'
+                >
                   {topic[0]}
                 </Text>
                 <Text fontSize='14px' w='26%'>
@@ -101,6 +110,7 @@ const TopicInstitutionMetadata = ({data }: {data: ResearchDataInterface}) => {
         </Box>
       )}
     </Flex>
-  )}
+  );
+};
 
 export default TopicInstitutionMetadata;

--- a/frontend/src/components/TopicInstitutionMetadata.tsx
+++ b/frontend/src/components/TopicInstitutionMetadata.tsx
@@ -3,6 +3,8 @@ import { Box, Flex, Text } from '@chakra-ui/react';
 import { ResearchDataInterface } from '../utils/interfaces';
 import TopicClusterGraphComponent from './TopicClusterGraphComponent';
 
+import { TransformTopicClustersForOrb } from './TransformTopicCluster.js';
+
 const TopicInstitutionMetadata = ({
   data,
   setResearcher,
@@ -14,36 +16,6 @@ const TopicInstitutionMetadata = ({
   const handleTopicClusterClick = () => {
     setTopicClusterGraph(!showTopicClusterGraph);
   }
-
-  const transformTopicClustersToGraph = (topicClusters: string[]) => {
-    const nodes: { id: string; label: string; type: string }[] = [];
-    const edges: { id: number; start: string; end: string }[] = [];
-
-    const topicNameId = `topic_${data?.topic_name}`;
-    nodes.push({
-      id: topicNameId,
-      label: data.topic_name,
-      type: 'TOPIC'
-    });
-
-    topicClusters.forEach((topic, id) => {
-      const subfieldNodeId = `subfield_${id}`;
-      nodes.push({
-        id: subfieldNodeId,
-        label: topic,
-        type: 'SUBFIELD',
-      });
-      edges.push({
-        id,
-        start: subfieldNodeId,
-        end: topicNameId,
-      });
-    });
-    return {
-      nodes,
-      edges,
-    };
-  };
   
   return (
     <Flex
@@ -84,7 +56,7 @@ const TopicInstitutionMetadata = ({
 
       {showTopicClusterGraph ? (
         <Box mt='1rem' w={{ lg: '70%' }} mx='auto'>
-          <TopicClusterGraphComponent graphData={transformTopicClustersToGraph(data?.topic_clusters)} />
+          <TopicClusterGraphComponent graphData={TransformTopicClustersForOrb(data, data?.topic_clusters)} />
         </Box>
       ) : (
         <Box w={{ lg: '64%' }} mt={{ base: '.9rem', lg: 0 }}>

--- a/frontend/src/components/TopicInstitutionMetadata.tsx
+++ b/frontend/src/components/TopicInstitutionMetadata.tsx
@@ -5,7 +5,7 @@ import { Box, Flex, Text } from '@chakra-ui/react';
 import { ResearchDataInterface } from '../utils/interfaces';
 import TopicClusterGraphComponent from './TopicClusterGraphComponent';
 
-const TopicInstitutionMetadata = ({data}: {data: ResearchDataInterface}) => {
+const TopicInstitutionMetadata = ({data, }: {data: ResearchDataInterface}) => {
   const [showTopicClusterGraph, setTopicClusterGraph] = useState(false);
   const handleTopicClusterClick = () => {
     setTopicClusterGraph(!showTopicClusterGraph)

--- a/frontend/src/components/TopicInstitutionMetadata.tsx
+++ b/frontend/src/components/TopicInstitutionMetadata.tsx
@@ -5,7 +5,8 @@ import { Box, Flex, Text } from '@chakra-ui/react';
 import { ResearchDataInterface } from '../utils/interfaces';
 import TopicClusterGraphComponent from './TopicClusterGraphComponent';
 
-const TopicInstitutionMetadata = ({data, }: {data: ResearchDataInterface}) => {
+const TopicInstitutionMetadata = ({data, setResearcher }: {data: ResearchDataInterface;
+  setResearcher: React.Dispatch<React.SetStateAction<string>>;}) => {
   const [showTopicClusterGraph, setTopicClusterGraph] = useState(false);
   const handleTopicClusterClick = () => {
     setTopicClusterGraph(!showTopicClusterGraph)

--- a/frontend/src/components/TopicInstitutionMetadata.tsx
+++ b/frontend/src/components/TopicInstitutionMetadata.tsx
@@ -107,6 +107,7 @@ const TopicInstitutionMetadata = ({
               </Flex>
             ))}
           </Box>
+          </Box>
       )}
     </Flex>
   );

--- a/frontend/src/components/TopicInstitutionMetadata.tsx
+++ b/frontend/src/components/TopicInstitutionMetadata.tsx
@@ -1,17 +1,47 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Box, Flex, Text } from '@chakra-ui/react';
 
 import { ResearchDataInterface } from '../utils/interfaces';
+import TopicClusterGraphComponent from './TopicClusterGraphComponent';
 
 const TopicInstitutionMetadata = ({data}: {data: ResearchDataInterface}) => {
+  const [showTopicClusterGraph, setTopicClusterGraph] = useState(false);
+  const handleTopicClusterClick = () => {
+    setTopicClusterGraph(!showTopicClusterGraph)
+  }
+
+  const transformTopicClustersToGraph = (topicClusters: string[]) => {
+    const nodes: { id: string; label: string; type: string; }[] = [];
+
+    const topicName = `topic_${data?.topic_name}`;
+    nodes.push({
+      id: topicName,
+      label: data.topic_name,
+      type: 'TOPIC'
+    });
+
+    topicClusters.forEach((topic, id) => {
+      const subfieldNodeId = `subfield_${id}`;
+      nodes.push({
+        id: subfieldNodeId,
+        label: topic,
+        type: 'SUBFIELD',
+      });
+      
+    });
+    return {
+      nodes,
+    };
+  };
+
   return (
-    <Flex
-      display={{base: 'block', lg: 'flex'}}
+      <Flex
+      display={{ base: 'block', lg:'flex'}}
       justifyContent={'space-between'}
       mt='0.6rem'
       className='list-map'
-    >
+      >
       <Box w={{lg: '34%'}}>
         <button className='topButton'>List Map</button>
         <h2>{data?.institution_name}</h2>
@@ -32,41 +62,45 @@ const TopicInstitutionMetadata = ({data}: {data: ResearchDataInterface}) => {
           RORID -{' '}
           {data?.ror_link?.split('/')[data?.ror_link?.split('/')?.length - 1]}
         </a>
+
         <Box mt='0.4rem'>
           <Text fontSize={'17px'} fontWeight={'600'}>
-            Topic Clusters
-          </Text>
-          <Box ml='2rem'>
-            {data?.topic_clusters?.map((cluster) => (
-              <Text mt='0.3rem'>{cluster}</Text>
+            <a style={{ cursor: 'pointer', 'textDecoration': 'underline' }} onClick={handleTopicClusterClick}>
+              Topic Clusters
+            </a>
+          </Text> 
+        </Box>
+      </Box>
+
+      {showTopicClusterGraph ? (
+        <Box mt='1rem' w={{lg: '70%'}} mx = 'auto'>
+            <TopicClusterGraphComponent graphData={transformTopicClustersToGraph(data?.topic_clusters)} />
+          </Box>) 
+        : (
+          <Box w={{lg: '64%'}} mt={{base: '.9rem', lg: 0}}>
+          <Box display={'flex'} justifyContent={'space-between'}>
+            <Text fontSize={'18px'} fontWeight={600} w='72%'>
+              Person
+            </Text>
+            <Text fontSize={'18px'} fontWeight={600} w='26%'>
+              No of works
+            </Text>
+          </Box>
+          <Box mt='.5rem'>
+            {data?.authors?.map((topic) => (
+              <Flex justifyContent={'space-between'}>
+                <Text fontSize='14px' w='72%'>
+                  {topic[0]}
+                </Text>
+                <Text fontSize='14px' w='26%'>
+                  {topic[1]}
+                </Text>
+              </Flex>
             ))}
           </Box>
         </Box>
-      </Box>
-      <Box w={{lg: '64%'}} mt={{base: '.9rem', lg: 0}}>
-        <Box display={'flex'} justifyContent={'space-between'}>
-          <Text fontSize={'18px'} fontWeight={600} w='72%'>
-            Person
-          </Text>
-          <Text fontSize={'18px'} fontWeight={600} w='26%'>
-            No of works
-          </Text>
-        </Box>
-        <Box mt='.5rem'>
-          {data?.authors?.map((topic) => (
-            <Flex justifyContent={'space-between'}>
-              <Text fontSize='14px' w='72%'>
-                {topic[0]}
-              </Text>
-              <Text fontSize='14px' w='26%'>
-                {topic[1]}
-              </Text>
-            </Flex>
-          ))}
-        </Box>
-      </Box>
+      )}
     </Flex>
-  );
-};
+  )}
 
 export default TopicInstitutionMetadata;

--- a/frontend/src/components/TopicInstitutionMetadata.tsx
+++ b/frontend/src/components/TopicInstitutionMetadata.tsx
@@ -5,11 +5,10 @@ import { Box, Flex, Text } from '@chakra-ui/react';
 import { ResearchDataInterface } from '../utils/interfaces';
 import TopicClusterGraphComponent from './TopicClusterGraphComponent';
 
-const TopicInstitutionMetadata = ({data, setResearcher }: {data: ResearchDataInterface;
-  setResearcher: React.Dispatch<React.SetStateAction<string>>;}) => {
+const TopicInstitutionMetadata = ({data }: {data: ResearchDataInterface}) => {
   const [showTopicClusterGraph, setTopicClusterGraph] = useState(false);
   const handleTopicClusterClick = () => {
-    setTopicClusterGraph(!showTopicClusterGraph)
+    setTopicClusterGraph(!showTopicClusterGraph);
   }
 
   const transformTopicClustersToGraph = (topicClusters: string[]) => {

--- a/frontend/src/components/TopicInstitutionMetadata.tsx
+++ b/frontend/src/components/TopicInstitutionMetadata.tsx
@@ -16,11 +16,12 @@ const TopicInstitutionMetadata = ({
   }
 
   const transformTopicClustersToGraph = (topicClusters: string[]) => {
-    const nodes: { id: string; label: string; type: string; }[] = [];
+    const nodes: { id: string; label: string; type: string }[] = [];
+    const edges: { id: number; start: string; end: string }[] = [];
 
-    const topicName = `topic_${data?.topic_name}`;
+    const topicNameId = `topic_${data?.topic_name}`;
     nodes.push({
-      id: topicName,
+      id: topicNameId,
       label: data.topic_name,
       type: 'TOPIC'
     });
@@ -32,9 +33,15 @@ const TopicInstitutionMetadata = ({
         label: topic,
         type: 'SUBFIELD',
       });
+      edges.push({
+        id,
+        start: subfieldNodeId,
+        end: topicNameId,
+      });
     });
     return {
       nodes,
+      edges,
     };
   };
   

--- a/frontend/src/components/TopicMetadata.tsx
+++ b/frontend/src/components/TopicMetadata.tsx
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Box, Flex, Text } from '@chakra-ui/react';
 
 import { ResearchDataInterface } from '../utils/interfaces';
+
+import { TransformTopicClustersForOrb } from './TransformTopicCluster.js';
+import TopicClusterGraphComponent from './TopicClusterGraphComponent';
 
 const TopicMetadata = ({
   data,
@@ -11,6 +14,10 @@ const TopicMetadata = ({
   data: ResearchDataInterface;
   setInstitution: React.Dispatch<React.SetStateAction<string>>;
 }) => {
+  const [showTopicClusterGraph, setTopicClusterGraph] = useState(false);
+  const handleTopicClusterClick = () => {
+    setTopicClusterGraph(!showTopicClusterGraph);
+  }
   return (
     <Flex
       display={{base: 'block', lg: 'flex'}}
@@ -23,13 +30,10 @@ const TopicMetadata = ({
         <h2>{data?.topic_name}</h2>
         <Box mt='0.4rem'>
           <Text fontSize={'17px'} fontWeight={'600'}>
-            Topic Clusters
+            <a style={{ cursor: 'pointer', textDecoration: 'underline' }} onClick={handleTopicClusterClick}>
+              Topic Clusters
+            </a>
           </Text>
-          <Box ml='2rem'>
-            {data?.topic_clusters?.map((cluster) => (
-              <Text mt='0.3rem'>{cluster}</Text>
-            ))}
-          </Box>
         </Box>
         <p>Total {data?.author_count} authors</p>
         <p>Total {data?.works_count} works</p>
@@ -47,7 +51,12 @@ const TopicMetadata = ({
             No of people
           </Text>
         </Box>
-        <Box mt='.5rem'>
+        {showTopicClusterGraph ? (
+          <Box mt='1rem' w={{ lg: '70%' }} mx='auto'>
+            <TopicClusterGraphComponent graphData={TransformTopicClustersForOrb(data, data?.topic_clusters)} />
+          </Box>
+        ) : (
+          <Box mt='.5rem'>
           {data?.organizations?.map((topic) => (
             <Flex justifyContent={'space-between'}>
               <Text
@@ -65,6 +74,7 @@ const TopicMetadata = ({
             </Flex>
           ))}
         </Box>
+        )}
       </Box>
     </Flex>
   );

--- a/frontend/src/components/TopicResearcherMetadata.tsx
+++ b/frontend/src/components/TopicResearcherMetadata.tsx
@@ -1,10 +1,19 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Box, Flex, Text } from '@chakra-ui/react';
 
 import { ResearchDataInterface } from '../utils/interfaces';
 
+import { TransformTopicClustersForOrb } from './TransformTopicCluster.js';
+import TopicClusterGraphComponent from './TopicClusterGraphComponent';
+
 const TopicResearcherMetadata = ({data}: {data: ResearchDataInterface}) => {
+
+  const [showTopicClusterGraph, setTopicClusterGraph] = useState(false);
+  const handleTopicClusterClick = () => {
+    setTopicClusterGraph(!showTopicClusterGraph);
+  }
+
   return (
     <Flex
       display={{base: 'block', lg: 'flex'}}
@@ -29,13 +38,10 @@ const TopicResearcherMetadata = ({data}: {data: ResearchDataInterface}) => {
         <p>Total {data?.cited_count} citations</p>
         <Box mt='0.4rem'>
           <Text fontSize={'17px'} fontWeight={'600'}>
-            Topic Clusters
+            <a style={{ cursor: 'pointer', textDecoration: 'underline' }} onClick={handleTopicClusterClick}>
+                Topic Clusters
+            </a>
           </Text>
-          <Box ml='2rem'>
-            {data?.topic_clusters?.map((cluster) => (
-              <Text mt='0.3rem'>{cluster}</Text>
-            ))}
-          </Box>
         </Box>
         <a target='_blank' rel='noreferrer' href={data?.open_alex_link}>
           View Keyword on OpenAlex
@@ -57,7 +63,12 @@ const TopicResearcherMetadata = ({data}: {data: ResearchDataInterface}) => {
             No of citations
           </Text>
         </Box>
-        <Box mt='.5rem'>
+        {showTopicClusterGraph ? (
+          <Box mt='1rem' w={{ lg: '70%' }} mx='auto'>
+            <TopicClusterGraphComponent graphData={TransformTopicClustersForOrb(data, data?.topic_clusters)} />
+        </Box>
+        ) : (
+          <Box mt='.5rem'>
           {data?.works?.map((topic) => (
             <Flex justifyContent={'space-between'}>
               <Text fontSize='14px' w='72%'>
@@ -69,6 +80,7 @@ const TopicResearcherMetadata = ({data}: {data: ResearchDataInterface}) => {
             </Flex>
           ))}
         </Box>
+        )}
       </Box>
     </Flex>
   );

--- a/frontend/src/components/TransformTopicCluster.js
+++ b/frontend/src/components/TransformTopicCluster.js
@@ -1,0 +1,29 @@
+export function TransformTopicClustersForOrb(data, topicClusters) {
+  const nodes = [];
+  const edges = [];
+
+  const topicNameId = `topic_${data?.topic_name}`;
+  nodes.push({
+    id: topicNameId,
+    label: data.topic_name,
+    type: "TOPIC",
+  });
+
+  topicClusters.forEach((topic, id) => {
+    const subfieldNodeId = `subfield_${id}`;
+    nodes.push({
+      id: subfieldNodeId,
+      label: topic,
+      type: "SUBFIELD",
+    });
+    edges.push({
+      id,
+      start: subfieldNodeId,
+      end: topicNameId,
+    });
+  });
+  return {
+    nodes,
+    edges,
+  };
+};


### PR DESCRIPTION
The detailed list of the topic clusters was removed and converted it into a link which when clicked will display those list into a graph like format. Used the existing format on which the network map was built on.