### PR TITLE
Adjust input component for institutions and delete network map button

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -132,7 +132,7 @@ const Home = () => {
                   {text: 'Organization (eg. University)', key: 'institution'},
                   {text: 'Type', key: 'type'},
                 ].map(({text, key}) => (
-                  <Box key={text}>
+                  <Box key={text} w={{base: '100%', lg:'auto'}}>
                     <Field name={key}>
                       {({field, form}: any) => (
                         <FormControl
@@ -145,9 +145,11 @@ const Home = () => {
                                 focusBorderColor='white'
                                 borderBottomWidth={'2px'}
                                 color='white'
-                                fontSize={{lg: '20px'}}
+                                fontSize={{base:'16px', lg: '20px'}}
                                 textAlign={'center'}
                                 list='institutions'
+                                w={'100%'}
+                                maxW={'100%'}
                                 {...field}
                                 onChange={(e) => {
                                   field.onChange(e);
@@ -173,6 +175,10 @@ const Home = () => {
                               fontSize={{lg: '20px'}}
                               textAlign={'center'}
                               {...field}
+                              sx={{
+                                textAlignLast: 'center',
+                                paddingLeft: '25px'
+                              }}
                             >
                               <option value='' style={{color: 'black'}}>
                                 Select an institution type

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -632,7 +632,7 @@ const Search = () => {
             </Box>
           ) : isNetworkMap === "graph" ? (
             <div className="network-map">
-              <button className="topButton">Network Map</button>
+             {/*<button className="topButton">Network Map</button>*/}
               {/* <img src={NetworkMap} alt='Network Map' /> */}
               <GraphComponent
                 graphData={data?.graph}


### PR DESCRIPTION
Deleted Network Map button that appears when viewing the graph.

To resolve the mobile freezing issue within the institutions input I adjusted the width of the Box component that contains the input. I also explicitly defined the max with and width of the input to make sure it is stretched across the container but not outside of the container on mobile view.


The alignment of the content in the institution type is aligned left during mobile view. To resolve I used styling prop sx to center value; sx allows inline styling to adjust alignment of chosen value.

<img width="1512" alt="networkmpbtn" src="https://github.com/user-attachments/assets/2cf6dd1b-6ac0-4f5a-a9dc-0d02433f1450" />

![IMG_3472](https://github.com/user-attachments/assets/c3d897bc-7287-4d73-bb28-218898c5bd48)


